### PR TITLE
Add instructions for manual step videos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Video assets
+public/videos/*.mp4

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 K\303\274chenseele
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-Website in process. README incoming soon.
+# Küchenseele Website
+
+Dies ist der Quellcode der deutschsprachigen Küchenwebseite **Küchenseele**. Das Projekt basiert auf Vite, React und TypeScript.
+
+## Lizenz
+
+Der Quellcode steht unter der [MIT-Lizenz](./LICENSE).
+
+## Bild- und Fontnachweise
+
+- Die Beispielbilder stammen von [Unsplash](https://unsplash.com) und unterliegen der Unsplash-Lizenz.
+- Die Schriftarten werden über [Google Fonts](https://fonts.google.com/) eingebunden.
+
+
+## Schritt-Videos
+
+Die Parallax-Videos für die Journey-Schritte befinden sich nicht im Repository. Lege deine eigenen Dateien unter `public/videos/step1.mp4`, `step2.mp4` und `step3.mp4` ab, um sie einzubinden.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,19 @@
 // src/App.tsx
 // Resolved merge conflict: keep the new Journey component
 
+import { useState } from "react";
 import LandingGrid from "./components/LandingGrid";
 import Journey from "./components/Journey";
 import Footer from "./components/Footer";
+import SplashScreen from "./components/SplashScreen";
 
 export default function App() {
+  const [showSplash, setShowSplash] = useState(true);
+
+  if (showSplash) {
+    return <SplashScreen onFinish={() => setShowSplash(false)} />;
+  }
+
   return (
     <div className="bg-[#f7f7f9] min-h-screen">
       <LandingGrid />

--- a/src/components/Journey.tsx
+++ b/src/components/Journey.tsx
@@ -7,29 +7,29 @@ export default function Journey() {
         step={1}
         title="Beratung & Planung"
         subtitle="Individuell und ehrlich"
-        description="Gemeinsam besprechen wir Ihre Wünsche und entwickeln ein maßgeschneidertes Konzept."
-        imageUrl="/kitchens/kitchen1.png"
+        description="Als Familienbetrieb aus Graz besprechen wir Ihre Wünsche persönlich und entwickeln ein maßgeschneidertes Konzept."
+        videoUrl="/videos/step1.mp4"
       />
       <JourneySection
         step={2}
         title="Materialauswahl"
         subtitle="Qualität zum Anfassen"
-        description="Sie wählen hochwertige Materialien, wir zeigen Ihnen die Möglichkeiten."
-        imageUrl="/kitchens/kitchen2.png"
+        description="Sie wählen hochwertige Materialien, wir zeigen Ihnen alle Möglichkeiten in Ruhe."
+        videoUrl="/videos/step2.mp4"
         isReversed
       />
       <JourneySection
         step={3}
         title="Handwerk & Montage"
         subtitle="Von Meisterhand gefertigt"
-        description="Wir fertigen jedes Stück präzise und montieren es fachgerecht bei Ihnen."
-        imageUrl="/kitchens/kitchen3.png"
+        description="In unserer Grazer Werkstatt entsteht Ihre Küche in liebevoller Handarbeit, bevor wir sie fachgerecht montieren."
+        videoUrl="/videos/step3.mp4"
       />
       <JourneySection
         step={4}
         title="Genießen"
         subtitle="Ihre Küche mit Seele"
-        description="Freuen Sie sich über Ihre einzigartige neue Küche."
+        description="Genießen Sie Ihr von Hand gefertigtes Unikat – gefertigt von unserem Familienbetrieb in Graz."
         imageUrl="/kitchens/kitchen4.png"
         isReversed
       />

--- a/src/components/JourneySection.tsx
+++ b/src/components/JourneySection.tsx
@@ -6,11 +6,22 @@ interface JourneySectionProps {
   title: string;
   subtitle: string;
   description: string;
-  imageUrl: string;
+  /** Optional image to display if no video is provided */
+  imageUrl?: string;
+  /** Optional video to display instead of an image */
+  videoUrl?: string;
   isReversed?: boolean;
 }
 
-const JourneySection = ({ step, title, subtitle, description, imageUrl, isReversed = false }: JourneySectionProps) => {
+const JourneySection = ({
+  step,
+  title,
+  subtitle,
+  description,
+  imageUrl,
+  videoUrl,
+  isReversed = false,
+}: JourneySectionProps) => {
   const [isVisible, setIsVisible] = useState(false);
   const [scrollY, setScrollY] = useState(0);
   const [textAnimationPhase, setTextAnimationPhase] = useState(0);
@@ -146,11 +157,22 @@ const JourneySection = ({ step, title, subtitle, description, imageUrl, isRevers
             }}
           >
             <div className="relative overflow-hidden rounded-3xl shadow-2xl group">
-              <img
-                src={imageUrl}
-                alt={title}
-                className="w-full h-80 md:h-96 object-cover transform group-hover:scale-110 transition-transform duration-700"
-              />
+              {videoUrl ? (
+                <video
+                  src={videoUrl}
+                  autoPlay
+                  loop
+                  muted
+                  playsInline
+                  className="w-full h-80 md:h-96 object-cover transform group-hover:scale-110 transition-transform duration-700"
+                />
+              ) : (
+                <img
+                  src={imageUrl}
+                  alt={title}
+                  className="w-full h-80 md:h-96 object-cover transform group-hover:scale-110 transition-transform duration-700"
+                />
+              )}
               <div className="absolute inset-0 bg-gradient-to-t from-wood-900/30 via-transparent to-transparent"></div>
               
               {/* Floating decorative elements */}

--- a/src/components/SplashScreen.tsx
+++ b/src/components/SplashScreen.tsx
@@ -1,6 +1,11 @@
-import { useRef } from "react";
+import { useEffect } from "react";
 
 export default function SplashScreen({ onFinish }: { onFinish: () => void }) {
+  useEffect(() => {
+    const timer = setTimeout(onFinish, 6000);
+    return () => clearTimeout(timer);
+  }, [onFinish]);
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black overflow-hidden">
       <video


### PR DESCRIPTION
## Summary
- remove placeholder step videos from the repo
- ignore MP4 assets in `public/videos`
- document where to place custom step videos

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857ebd2ee68832b89130793f3a1eaaf