### PR TITLE
Add parallax video steps with splash screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Video assets
+public/videos/*.mp4

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 K\303\274chenseele
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-Website in process. README incoming soon.
+# Küchenseele Website
+
+Dies ist der Quellcode der deutschsprachigen Küchenwebseite **Küchenseele**. Das Projekt basiert auf Vite, React und TypeScript.
+
+## Lizenz
+
+Der Quellcode steht unter der [MIT-Lizenz](./LICENSE).
+
+## Bild- und Fontnachweise
+
+- Die Beispielbilder stammen von [Unsplash](https://unsplash.com) und unterliegen der Unsplash-Lizenz.
+- Die Schriftarten werden über [Google Fonts](https://fonts.google.com/) eingebunden.
+
+
+## Schritt-Videos
+
+Die Parallax-Videos für die Journey-Schritte befinden sich nicht im Repository. Lege deine eigenen Dateien unter `public/videos/step1.mp4`, `step2.mp4` und `step3.mp4` ab, um sie einzubinden.
+
+## Features
+- Interaktive Startseite mit kippenden Kacheln
+- Parallax-Videos in der Journey-Sektion
+- Splash-Screen beim Laden
+- Portfolio mit abgeschlossenen Projekten

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,25 @@
 // src/App.tsx
 // Resolved merge conflict: keep the new Journey component
 
+import { useState } from "react";
 import LandingGrid from "./components/LandingGrid";
 import Journey from "./components/Journey";
+import Portfolio from "./components/Portfolio";
 import Footer from "./components/Footer";
+import SplashScreen from "./components/SplashScreen";
 
 export default function App() {
+  const [showSplash, setShowSplash] = useState(true);
+
+  if (showSplash) {
+    return <SplashScreen onFinish={() => setShowSplash(false)} />;
+  }
+
   return (
     <div className="bg-[#f7f7f9] min-h-screen">
       <LandingGrid />
       <Journey />
+      <Portfolio />
       <Footer />
     </div>
   );

--- a/src/components/Journey.tsx
+++ b/src/components/Journey.tsx
@@ -7,29 +7,29 @@ export default function Journey() {
         step={1}
         title="Beratung & Planung"
         subtitle="Individuell und ehrlich"
-        description="Gemeinsam besprechen wir Ihre Wünsche und entwickeln ein maßgeschneidertes Konzept."
-        imageUrl="/kitchens/kitchen1.png"
+        description="Als Familienbetrieb aus Graz nehmen wir uns Zeit für Sie: In einem persönlichen Gespräch besprechen wir alle Wünsche und Ideen und entwickeln daraufhin ein maßgeschneidertes Konzept."
+        videoUrl="/videos/step1.mp4"
       />
       <JourneySection
         step={2}
         title="Materialauswahl"
         subtitle="Qualität zum Anfassen"
-        description="Sie wählen hochwertige Materialien, wir zeigen Ihnen die Möglichkeiten."
-        imageUrl="/kitchens/kitchen2.png"
+        description="Sie wählen aus hochwertigen Materialien – wir beraten Sie ausführlich zu den Möglichkeiten und kombinieren Farben, Oberflächen und Beschläge ganz nach Ihrem Geschmack."
+        videoUrl="/videos/step2.mp4"
         isReversed
       />
       <JourneySection
         step={3}
         title="Handwerk & Montage"
         subtitle="Von Meisterhand gefertigt"
-        description="Wir fertigen jedes Stück präzise und montieren es fachgerecht bei Ihnen."
-        imageUrl="/kitchens/kitchen3.png"
+        description="In unserer Werkstatt in Graz fertigen wir Ihre Küche mit viel Liebe zum Detail. Jedes Stück entsteht in präziser Handarbeit, bevor wir es bei Ihnen vor Ort passgenau montieren."
+        videoUrl="/videos/step3.mp4"
       />
       <JourneySection
         step={4}
         title="Genießen"
         subtitle="Ihre Küche mit Seele"
-        description="Freuen Sie sich über Ihre einzigartige neue Küche."
+        description="Genießen Sie Ihr handgefertigtes Unikat aus unserem Familienbetrieb in Graz. Nach der Montage stehen wir Ihnen selbstverständlich weiter mit Rat und Tat zur Seite."
         imageUrl="/kitchens/kitchen4.png"
         isReversed
       />

--- a/src/components/JourneySection.tsx
+++ b/src/components/JourneySection.tsx
@@ -6,11 +6,22 @@ interface JourneySectionProps {
   title: string;
   subtitle: string;
   description: string;
-  imageUrl: string;
+  /** Optional image to display if no video is provided */
+  imageUrl?: string;
+  /** Optional video to display instead of an image */
+  videoUrl?: string;
   isReversed?: boolean;
 }
 
-const JourneySection = ({ step, title, subtitle, description, imageUrl, isReversed = false }: JourneySectionProps) => {
+const JourneySection = ({
+  step,
+  title,
+  subtitle,
+  description,
+  imageUrl,
+  videoUrl,
+  isReversed = false,
+}: JourneySectionProps) => {
   const [isVisible, setIsVisible] = useState(false);
   const [scrollY, setScrollY] = useState(0);
   const [textAnimationPhase, setTextAnimationPhase] = useState(0);
@@ -146,11 +157,22 @@ const JourneySection = ({ step, title, subtitle, description, imageUrl, isRevers
             }}
           >
             <div className="relative overflow-hidden rounded-3xl shadow-2xl group">
-              <img
-                src={imageUrl}
-                alt={title}
-                className="w-full h-80 md:h-96 object-cover transform group-hover:scale-110 transition-transform duration-700"
-              />
+              {videoUrl ? (
+                <video
+                  src={videoUrl}
+                  autoPlay
+                  loop
+                  muted
+                  playsInline
+                  className="w-full h-80 md:h-96 object-cover transform group-hover:scale-110 transition-transform duration-700"
+                />
+              ) : (
+                <img
+                  src={imageUrl}
+                  alt={title}
+                  className="w-full h-80 md:h-96 object-cover transform group-hover:scale-110 transition-transform duration-700"
+                />
+              )}
               <div className="absolute inset-0 bg-gradient-to-t from-wood-900/30 via-transparent to-transparent"></div>
               
               {/* Floating decorative elements */}

--- a/src/components/LandingGrid.tsx
+++ b/src/components/LandingGrid.tsx
@@ -9,13 +9,13 @@ export default function LandingGrid() {
         <div className="grid grid-cols-12 grid-rows-6 gap-6 h-[93vh]">
 
           {/* Küchen-Slideshow */}
-          <div className="col-span-7 row-span-4 bg-white rounded-2xl shadow-lg flex items-center justify-center overflow-hidden relative">
+          <div className="col-span-7 row-span-4 bg-white rounded-2xl shadow-lg flex items-center justify-center overflow-hidden relative transform transition-transform duration-300 hover:-rotate-2">
             <KitchenSlideshow />
             <div className="absolute inset-0 bg-black/10 pointer-events-none rounded-2xl" />
           </div>
 
           {/* Vertikaler Satz: Machs dir selbst mit Hintergrundbild */}
-          <div className="col-start-8 col-span-1 row-span-4 rounded-2xl shadow-lg flex items-center justify-center relative overflow-hidden">
+          <div className="col-start-8 col-span-1 row-span-4 rounded-2xl shadow-lg flex items-center justify-center relative overflow-hidden transform transition-transform duration-300 hover:-rotate-2">
             <img
               src="/kitchens/landingbeige.png"
               alt=""
@@ -28,13 +28,13 @@ export default function LandingGrid() {
           </div>
 
           {/* Flur-Slideshow */}
-          <div className="col-start-9 col-span-4 row-span-4 bg-white rounded-2xl shadow-lg flex items-center justify-center overflow-hidden relative">
+          <div className="col-start-9 col-span-4 row-span-4 bg-white rounded-2xl shadow-lg flex items-center justify-center overflow-hidden relative transform transition-transform duration-300 hover:-rotate-2">
             <FlurSlideshow />
             <div className="absolute inset-0 bg-black/10 pointer-events-none rounded-2xl" />
           </div>
 
           {/* Firmenname: Küchenseele mit Bildhintergrund */}
-          <div className="col-span-7 row-start-5 row-span-2 rounded-2xl shadow-lg flex items-center justify-center relative overflow-hidden">
+          <div className="col-span-7 row-start-5 row-span-2 rounded-2xl shadow-lg flex items-center justify-center relative overflow-hidden transform transition-transform duration-300 hover:-rotate-2">
             <img
               src="/kitchens/namebg.png"
               alt=""
@@ -47,16 +47,16 @@ export default function LandingGrid() {
           </div>
 
           {/* Materialien: 4 Kacheln mit perfekt skalierten Bildern */}
-          <div className="col-start-8 col-span-3 row-start-5 row-span-2 bg-white rounded-2xl shadow-lg grid grid-cols-2 grid-rows-2 gap-3 p-4">
+          <div className="col-start-8 col-span-3 row-start-5 row-span-2 bg-white rounded-2xl shadow-lg grid grid-cols-2 grid-rows-2 gap-3 p-4 transform transition-transform duration-300 hover:-rotate-2">
             {["fibo1", "fibo2", "fibo3", "fibo4"].map((fibo) => (
               <div
                 key={fibo}
-                className="rounded-xl overflow-hidden aspect-square w-full h-full flex items-center justify-center bg-gray-100"
+                className="rounded-xl overflow-hidden aspect-square w-full h-full flex items-center justify-center bg-gray-100 group"
               >
                 <img
                   src={`/kitchens/${fibo}.png`}
                   alt=""
-                  className="w-full h-full object-cover object-center transition-transform duration-300"
+                  className="w-full h-full object-cover object-center transition-transform duration-300 group-hover:-rotate-2"
                   draggable={false}
                   style={{
                     width: "100%",
@@ -65,7 +65,9 @@ export default function LandingGrid() {
                     objectPosition: "center",
                     display: "block",
                   }}
-                  onError={e => { (e.target as HTMLImageElement).style.opacity = "0.2" }}
+                  onError={(e) => {
+                    (e.target as HTMLImageElement).style.opacity = "0.2";
+                  }}
                 />
               </div>
             ))}
@@ -74,7 +76,7 @@ export default function LandingGrid() {
           {/* Beratung starten Kachel */}
           <div className="col-start-11 col-span-1 row-start-5 row-span-2 flex items-center justify-center">
             <div
-              className="w-full h-full rounded-2xl flex items-center justify-center"
+              className="w-full h-full rounded-2xl flex items-center justify-center transform transition-transform duration-300 hover:-rotate-2"
               style={{
                 background: 'linear-gradient(135deg, #36432B 70%, #463727 100%)',
                 boxShadow: '0 4px 24px rgba(54,67,43,0.10)',
@@ -92,7 +94,7 @@ export default function LandingGrid() {
           {/* Drück mich Button (gleiche Größe, rechts daneben) */}
           <div className="col-start-12 col-span-1 row-start-5 row-span-2 flex items-center justify-center">
             <div
-              className="w-full h-full rounded-2xl flex items-center justify-center bg-black shadow-lg"
+              className="w-full h-full rounded-2xl flex items-center justify-center bg-black shadow-lg transform transition-transform duration-300 hover:-rotate-2"
             >
               <button
                 className="w-full h-full text-white text-xl font-semibold flex flex-col items-center justify-center focus:outline-none"

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -110,7 +110,7 @@ const Portfolio = () => {
   };
 
   return (
-    <section className="min-h-screen bg-gradient-to-b from-cream-50 to-wood-50 py-20">
+    <section id="portfolio" className="min-h-screen bg-gradient-to-b from-cream-50 to-wood-50 py-20">
       <div className="container mx-auto px-4">
         <div className="text-center mb-16 animate-fade-in">
           <h2 className="font-playfair text-5xl md:text-6xl font-bold text-wood-800 mb-6">

--- a/src/components/SplashScreen.tsx
+++ b/src/components/SplashScreen.tsx
@@ -1,6 +1,11 @@
-import { useRef } from "react";
+import { useEffect } from "react";
 
 export default function SplashScreen({ onFinish }: { onFinish: () => void }) {
+  useEffect(() => {
+    const timer = setTimeout(onFinish, 6000);
+    return () => clearTimeout(timer);
+  }, [onFinish]);
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black overflow-hidden">
       <video

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
   darkMode: ["class"],
@@ -173,5 +174,5 @@ export default {
       }
     }
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [animate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- provide MIT license and asset attributions
- ignore video assets
- show a splash screen before the main app
- replace journey images with parallax videos and expanded text
- tilt landing tiles on hover and add portfolio section
- import tailwind plugin correctly and fix lint errors

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857ebd2ee68832b89130793f3a1eaaf